### PR TITLE
Fix: Removed overlapping of text

### DIFF
--- a/buklod-tao-branch/js/index.js
+++ b/buklod-tao-branch/js/index.js
@@ -77,7 +77,7 @@ function onPinClick(doc) {
         <p class="leafletDetails">${doc.residency_status}</p>
         <p class="leafletDetails">${doc.is_hoa_noa}</p>
       </div>
-      <div style="line-height: 3px; margin-bottom: 2px;">
+      <div style="line-height: 105%; margin-bottom: 2px;">
         <label class="leafletLabel">Nearest Evacuation Area</label>
         <p class="leafletDetails">${doc.nearest_evac}</p>
       </div>


### PR DESCRIPTION
The reason it was overlapping was because of the line-height being too small